### PR TITLE
Fixed issues on desktop and with background

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <br>
         <button id="clear-btn">Clear</button>
         <button id="save-btn">Save (as PNG)</button>
-        <script src="whiteboard.js"></script>
+        <script src="script.js"></script>
     </body>
-    <script src="script.js"></script>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ var whiteboard = {
 		this.canvas.addEventListener("touchstart", this.startDraw.bind(this));
 		this.canvas.addEventListener("touchmove", this.draw.bind(this));
 		this.canvas.addEventListener("touchend", this.endDraw.bind(this));
+
 		
 		// Attach event listener to the clear button
 		document.getElementById("clear-btn").addEventListener("click", this.clear.bind(this));
@@ -38,6 +39,9 @@ var whiteboard = {
 		
 		this.canvas.width = width;
 		this.canvas.height = height;
+
+		this.ctx.fillStyle = "white";
+		this.ctx.fillRect(0, 0, canvas.width, canvas.height);
 		
 		var buttons = document.querySelectorAll("button");
 		for (var i = 0; i < buttons.length; i++) {
@@ -50,8 +54,13 @@ var whiteboard = {
 	// Start drawing
 	startDraw: function(event) {
 		// Begin a new path on the canvas
+
 		this.ctx.beginPath();
 		
+		
+
+		this.ctx.lineTo(event.clientX - this.canvas.offsetLeft, event.clientY - this.canvas.offsetTop);
+
 		// Move the starting point to the current position
 		var x, y;
 		if (event.type === "mousedown") {
@@ -69,6 +78,10 @@ var whiteboard = {
 	draw: function(event) {
 		// Prevent scrolling on the canvas
 		event.preventDefault();
+
+		if (event.buttons !== 1) {
+			return;
+		}
 		
 		// Draw a line to the current position
 		var x, y;
@@ -94,10 +107,11 @@ var whiteboard = {
 	endDraw: function(event) {
 		// End the path
 		this.ctx.closePath();
+		this.drawing = false;	
 		},
+
 	// Clear the canvas
 	clear: function() {
-		// Clear the canvas
 		this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 	},
 	

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,7 @@ canvas {
 	max-width: 500px;
 	height: 50vh;
 	max-height: 500px;
+	background: white;
 }
 
 button {


### PR DESCRIPTION
- Fixed an issue on desktop where canvas was always drawing which began after adding mobile functionality
- Made background opaque by changing alpha to false. Previously the background was transparent by default due to canvas default settings
- Added a white background by rendering a white rectangle that is the same size and the canvas